### PR TITLE
Switch type check of "a" in isEqual() to includes()

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,7 +67,7 @@ export const isEqual = (a: JsonValueType, b: JsonValueType): boolean => {
     );
   }
 
-  if (typeof a in ["number", "boolean", "string"]) return a === b;
+  if (["number", "boolean", "string"].includes(typeof a)) return a === b;
 
   if (typeof a !== "object") return false; // It shouldn't happen as the type of a is jsonValue
   if (typeof b !== "object" || Array.isArray(b) || b === null) return false;


### PR DESCRIPTION
Why:

The previous version of the code used the "in" operator. However the "in"  operator checks for the presence of the left hand value in the properties of the object, which is not the intent here as we have an array listing the values we care for

What: Switch to using the includes() method of the array which is ES6 (ES2015) and later compatible